### PR TITLE
Improved Kount Job error handling

### DIFF
--- a/cartridges/int_kount/cartridge/scripts/jobs/processKountENSQueue.js
+++ b/cartridges/int_kount/cartridge/scripts/jobs/processKountENSQueue.js
@@ -4,6 +4,8 @@ var Transaction = require('dw/system/Transaction');
 var CustomObjectMgr = require('dw/object/CustomObjectMgr');
 var OrderMgr = require('dw/order/OrderMgr');
 var Logger = require('dw/system/Logger').getLogger('kount', 'kountensqueue');
+var Site = require('dw/system/Site');
+var siteID = Site.current.ID;
 
 /**
  * Processes an ENS Event
@@ -16,14 +18,13 @@ function processENSEvent(EventHub, kount, event) {
     if (eventRunner && event.orderNo) {
         try {
             eventRunner(event);
-        } catch (e) {
-            Logger.error('Cannot process kount ENS event entry. Error: ' + e.message + '\n' + e.stack);
-            kount.writeExecutionError(new Error('KOUNT: ProcessKountENSQueue.js: EventHub: Order with number - ' + event.orderNo + ' failed to update. Stack: ' + e.stack), 'KountEventHub', 'error');
-            try {
-                var order = OrderMgr.getOrder(event.orderNo);
+        } catch (error) {
+            Logger.error('[' + siteID +'] Failed to flag order after failing to update order ' + event.orderNo);
+            kount.writeExecutionError(new Error('[' + siteID +'] KOUNT: ProcessKountENSQueue.js: EventHub: Order with number - ' + event.orderNo + ' failed to update. Stack: ' + error.stack), 'KountEventHub', 'error');
+
+            var order = OrderMgr.getOrder(event.orderNo);
+            if (order) {
                 order.custom.kount_ENSF = true;
-            } catch (err) {
-                Logger.error('Failed to flag order after failing to update order. Error: ' + err.message + '\n' + err.stack);
             }
         }
     }
@@ -61,7 +62,7 @@ function execute() {
                 Transaction.commit();
             } catch (e) {
                 Transaction.rollback();
-                Logger.error('Failed to process ENS Record: ' + e.message + '\n' + e.stack);
+                Logger.error('[' + siteID +'] Failed to process ENS Record: ' + e.message + '\n' + e.stack);
                 break;
             }
         }


### PR DESCRIPTION
We had cases in Production when error handling did not work correctly because of possible Exception error.

**Changes**
- In `processENSEvent` function if order does not exist `order.custom.kount_ENSF = true` will trigger an Exception which will not be handled by try/catch block and the Job will fail without any useful logs about the reason. Added null check condition to cover this case
- Added siteID to the logs for better understanding which order (from which Site) triggered it
- renamed `e` in catch to `error` since `e` already used in the upper try/catch block and it creates collision

This fix applied and tested in the real project in Production