### PR TITLE
Made channel configurable using existing custom preference

### DIFF
--- a/cartridges/int_kount_360_sfra/cartridge/scripts/helpers/kount360OrderModel.js
+++ b/cartridges/int_kount_360_sfra/cartridge/scripts/helpers/kount360OrderModel.js
@@ -199,12 +199,16 @@ function getKountTransactions(order) {
 
 /**
  * Builds kount360 Order api request using SFCC order data
- * @param {dw.order.order} order - Requested order
+ * @param {dw.order.Order} order - Requested order
  * @returns {Object} requestData - Requested data object
  */
 function buildkount360OrderRequest(order) {
-    var Site = require('dw/system/Site');
-    var currentSite = Site.getCurrent();
+    var kount = require('*/cartridge/scripts/kount/libKount');
+    var channel = kount.getWebsiteID();
+    if (!channel) {
+        var Site = require('dw/system/Site');
+        channel = Site.getCurrent().ID.toUpperCase();
+    }
     var requestData = {};
     try {
         if (!order) {
@@ -212,7 +216,7 @@ function buildkount360OrderRequest(order) {
         }
         // Top-level fields
         requestData.merchantOrderId = order.orderNo || '';
-        requestData.channel = currentSite && currentSite.ID.toUpperCase();
+        requestData.channel = channel;
         // eslint-disable-next-line no-undef
         requestData.deviceSessionId = session.privacy.sessId || '';
         requestData.creationDateTime = order.creationDate ? order.creationDate.toISOString() : null;


### PR DESCRIPTION
This resolves an issue with hardcoding channel by Site ID which is the same across different instances (DEV/STG/PRD)
As a result, previously placed orders from different instances went to same channel in Kount
Used existing channel preference from legacy Kount integration