### PR TITLE
Legacy compatibility mode support

### DIFF
--- a/cartridges/int_kount_360_sfra/cartridge/scripts/helpers/kountWebhookValidator.js
+++ b/cartridges/int_kount_360_sfra/cartridge/scripts/helpers/kountWebhookValidator.js
@@ -18,10 +18,19 @@ function validateTimestamp(timestampHeader) {
 
     try {
         var eventTime = new Date(timestampHeader).getTime();
-        var currentTime = new Date().getTime();
-        var timeDifference = Math.abs(currentTime - eventTime) / 1000;
-
-        return timeDifference <= gracePeriod;
+        if (eventTime) {
+            var currentTime = new Date().getTime();
+            var timeDifference = Math.abs(currentTime - eventTime) / 1000;
+            return timeDifference <= gracePeriod;
+        } else {
+            // Handle case for old SFCC Compatibility Mode instances where Date parsing fails
+            var Calendar = require('dw/util/Calendar');
+            var dateOffset = Date.now() - gracePeriod * 1000;
+            var offsetCalendar = new Calendar(new Date(dateOffset));
+            var eventCalendar = new Calendar();
+            eventCalendar.parseByFormat(timestampHeader, "yyyy-MM-dd'T'HH:mm:ss'Z'");
+            return eventCalendar.compareTo(offsetCalendar) >= 0;
+        }
     } catch (e) {
         return false;
     }


### PR DESCRIPTION
In previous Compatibility modes Date constructor failed to create a date from string in example format "2015-10-01T18:55:44Z" 

Screenshot example from Compatibility Mode 18.10
<img width="1477" height="782" alt="image" src="https://github.com/user-attachments/assets/568080f6-9930-43d4-9bfc-5eb3f00a1d8b" />

Used Calendar for such cases